### PR TITLE
Fix autoloading namespace in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "autoload": {
         "psr-0": {
-            "emberlabs\\gravatarlib\\": ""
+            "emberlabs\\GravatarLib\\": ""
         }
     },
     "target-dir" : "emberlabs/gravatarlib"

--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,5 @@
             "emberlabs\\GravatarLib\\": ""
         }
     },
-    "target-dir" : "emberlabs/gravatarlib"
+    "target-dir" : "emberlabs/GravatarLib"
 }


### PR DESCRIPTION
It's need, because Gravatar class use namespace with uppercase letters. Autoload doesn't work.
